### PR TITLE
fix:  SemVer 2.0.0 issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thednp/shorty",
-  "version": "2.0.0alpha22",
+  "version": "2.0.0-alpha22",
   "description": "TypeScript shorties for the web",
   "source": "./src/index.ts",
   "main": "./dist/shorty.js",


### PR DESCRIPTION
This PR should fix the issue of the invalid SemVer 2.0.0 version (notably experienced by Azure users, in projects using compodoc).